### PR TITLE
Additional proxy settings

### DIFF
--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -7,19 +7,27 @@
 ---@field colortree_owner Player
 
 ---@alias dupeFunc fun(ply: Player, ent: Entity, data: any)
+---@alias resetFunc fun(ply: Player, ent: Entity, data: any, proxyName: string)
 ---@alias dataFunc fun(data: ProxyField): any
 
 ---Table of functions to transform entity proxy data and apply or reset it
----@alias ProxyTransformer {apply: dupeFunc, transform: dataFunc, reset: dupeFunc}
+---@alias ProxyTransformer {apply: dupeFunc, transform: dataFunc, reset: resetFunc}
 
 ---Mapping of material proxies to function tables that transforms data and applies proxies
 ---@alias ProxyTransformers {[MaterialProxy]: ProxyTransformer}
 
----@class ProxyData
+---@alias ProxyData {[ConVarName]: number|boolean}
+
 ---@alias ProxyField {color: Color, data: ProxyData}
 
 ---@alias MaterialProxy string
 ---@alias ProxyColor {[MaterialProxy]: ProxyField}?
+
+---@alias ConVarName string
+---@alias DermaClass string
+
+---@alias ProxyConVar {[1]: ConVarName, [2]: DermaClass}
+---@alias ProxyConVarMap {[MaterialProxy]: table<ProxyConVar>}
 
 ---Dupe data for color trees
 ---@class ColorTreeData

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -6,8 +6,11 @@
 ---@field ProxyentPaintColor Entity
 ---@field colortree_owner Player
 
+---@class ProxyData
+---@alias ProxyField {color: Color, data: ProxyData}
+
 ---@alias MaterialProxy string
----@alias ProxyColor {[MaterialProxy]: Color}?
+---@alias ProxyColor {[MaterialProxy]: ProxyField}?
 
 ---Dupe data for color trees
 ---@class ColorTreeData

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -6,6 +6,15 @@
 ---@field ProxyentPaintColor Entity
 ---@field colortree_owner Player
 
+---@alias dupeFunc fun(ply: Player, ent: Entity, data: any)
+---@alias dataFunc fun(data: ProxyField): any
+
+---Table of functions to transform entity proxy data and apply or reset it
+---@alias ProxyTransformer {apply: dupeFunc, transform: dataFunc, reset: dupeFunc}
+
+---Mapping of material proxies to function tables that transforms data and applies proxies
+---@alias ProxyTransformers {[MaterialProxy]: ProxyTransformer}
+
 ---@class ProxyData
 ---@alias ProxyField {color: Color, data: ProxyData}
 

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -42,8 +42,8 @@
 ---@field route integer[]?
 ---@field entity integer
 ---@field color Color
----@field renderMode number|RENDERMODE
----@field renderFx number|kRenderFx
+---@field renderMode number
+---@field renderFx number
 ---@field proxyColor ProxyColor?
 ---@field children DescendantTree[]
 
@@ -58,6 +58,11 @@
 ---@field ancestor ColorTreePanel_Node
 ---@field GetSelectedItem fun(self: ColorTreePanel): ColorTreePanel_Node
 
+---Wrapper for `DColorMixer`
+---@class ColorTreeMixer: DColorMixer
+---@field HSV DSlider
+
 ---Wrapper for `CtrlColor`
 ---@class ColorTreePicker: Panel
 ---@field SetLabel fun(self: ColorTreePicker, label: string)
+---@field Mixer ColorTreeMixer

--- a/lua/weapons/gmod_tool/stools/colortree.lua
+++ b/lua/weapons/gmod_tool/stools/colortree.lua
@@ -853,6 +853,8 @@ function TOOL.BuildCPanel(cPanel, colorable)
 		haloedEntity = Entity(node.info.entity)
 	end
 
+	-- TODO: During sync, update entity's appearance live in client, but send results
+	-- on a longer tick or if done editing a slider or color combo
 	local lastColor = {}
 	timer.Create("colortree_think", 0, -1, function()
 		if lock:GetChecked() then


### PR DESCRIPTION
- BREAKING: Changed proxyColor data structure. Dupes made before this version will not sync properly.
- Added TF2 cloak material proxy from the [Cloak Effect Tool](https://steamcommunity.com/sharedfiles/filedetails/?id=608061297)
- Optimize color syncing between server and client to reduce the outgoing net rate. Compared to the old version, this improves the average outgoing net rate fivefold (~12 kb/s compared to ~60 kb/s)
- Refactor variable names and refine typing