### PR TITLE
Advanced Colour Tool Support

### DIFF
--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -10,6 +10,9 @@ local getValidModelChildren, encodeData = helpers.getValidModelChildren, helpers
 
 local ui = {}
 
+---@type colortree_submaterials
+local submaterialFrame = nil
+
 local function getBoolOrFloatConVar(convar, isBool)
 	return GetConVar(convar) and Either(isBool, GetConVar(convar):GetBool(), GetConVar(convar):GetFloat())
 end
@@ -199,6 +202,9 @@ local function addNode(parent, entity, info, rootInfo)
 		local menu = DermaMenu()
 		if node.info.proxyColor then
 			menu:AddOption("Reset All", function()
+				if IsValid(submaterialFrame) then
+					submaterialFrame:ClearSelection()
+				end
 				resetTree(info)
 				syncTree(rootInfo)
 			end)
@@ -374,8 +380,6 @@ local function buildTree(treePanel, entity)
 	return hierarchy
 end
 
----@type colortree_submaterials
-local submaterialFrame = nil
 local ignore = false
 
 ---Set the entity for the submaterial frame.
@@ -521,6 +525,9 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 	local reset = panelChildren.reset
 
 	function reset:DoClick()
+		if IsValid(submaterialFrame) then
+			submaterialFrame:ClearSelection()
+		end
 		resetTree(panelState.colorTree)
 		syncTree(panelState.colorTree)
 	end

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -6,7 +6,8 @@ local proxyConVarMap = include("colortree/client/proxyConVars.lua")
 local pt = include("colortree/shared/proxyTransformers.lua")
 local proxyTransformers = pt.proxyTransformers
 
-local getValidModelChildren, encodeData = helpers.getValidModelChildren, helpers.encodeData
+local getValidModelChildren, encodeData, isAdvancedColorsInstalled =
+	helpers.getValidModelChildren, helpers.encodeData, helpers.isAdvancedColorsInstalled
 
 local ui = {}
 
@@ -687,7 +688,7 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 		local entity = Entity(node.info.entity)
 		---@cast entity Colorable
 
-		if isfunction(entity.SetSubColor) then
+		if isAdvancedColorsInstalled(entity) then
 			setSubMaterialEntity(entity, table.GetKeys(node.info.colors), panelChildren, panelState)
 		end
 		ignore = true
@@ -703,8 +704,8 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 	if IsValid(treePanel) and IsValid(treePanel.ancestor) then
 		treePanel:SetSelectedItem(treePanel.ancestor)
 		-- FIXME: Creates the submaterial frame twice. Could we circumvent this?
-		if IsValid(submaterialFrame) then
-			setSubMaterialEntity(colorable, table.GetKeys(colorable._adv_colours), panelChildren, panelState)
+		if isAdvancedColorsInstalled(colorable) then
+			setSubMaterialEntity(colorable, table.GetKeys(colorable._adv_colours or {}), panelChildren, panelState)
 		end
 		refreshTree(panelState.colorTree)
 	end

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -455,7 +455,9 @@ function ui.ConstructPanel(cPanel, panelProps, panelState)
 
 	local colorForm = makeCategory(cPanel, "Color", "ControlPanel")
 	colorForm:Help("#tool.colortree.color")
-	local colorPicker = colorForm:ColorPicker("Color", "colour_r", "colour_g", "colour_b", "colour_a")
+	---INFO: ColorPicker also accepts no convars.
+	---@diagnostic disable-next-line
+	local colorPicker = colorForm:ColorPicker("Color")
 	---@cast colorPicker ColorTreePicker
 	local renderMode = colorForm:ComboBox("Render Mode", "")
 	local renderFx = colorForm:ComboBox("Render FX", "")

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -415,6 +415,12 @@ local function setSubMaterialEntity(entity, submaterials, panelChildren, panelSt
 			node.info.colors[id] = nil
 			syncTree(panelState.colorTree)
 		end
+
+		function submaterialFrame:OnClearSelection()
+			local node = panelChildren.treePanel:GetSelectedItem()
+			node.info.colors = {}
+			syncTree(panelState.colorTree)
+		end
 	end
 end
 

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -168,7 +168,10 @@ end
 ---@param tree ColorTree
 local function refreshTree(tree)
 	local entity = tree.entity and Entity(tree.entity) or NULL
+	---@cast entity Colorable
+
 	tree.color = IsValid(entity) and entity:GetColor() or color_white
+	tree.colors = table.Copy(entity._adv_colours)
 	if not tree.children or #tree.children == 0 then
 		return
 	end
@@ -271,12 +274,18 @@ local function addChoiceFromRenders(comboBox, renderList)
 end
 
 ---Construct a flat array of the entity's descendant colors
----@param entity Entity
+---@param entity Colorable|Entity
 ---@param tbl Color[]
 ---@return Color[]
 local function getColorChildrenIdentifier(entity, tbl)
 	if not IsValid(entity) then
 		return {}
+	end
+
+	if entity._adv_colours and next(entity._adv_colours) then
+		for _, color in pairs(entity._adv_colours) do
+			table.insert(tbl, color)
+		end
 	end
 
 	local children = getValidModelChildren(entity)
@@ -730,6 +739,11 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 		-- Whether we should receive updates from the server or not.
 		-- Useful if we want an external source to modify the colors of the entity
 		if lock:GetChecked() then
+			return
+		end
+
+		-- Don't check color children until we are done editing the colors
+		if editing then
 			return
 		end
 

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -679,7 +679,7 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 
 		setColorClient(panelState.colorTree)
 
-		local h, s, v = ColorToHSV(newColor or color_white)
+		local h, s, v = ColorToHSV(newColor)
 		panelState.haloColor = HSVToColor(math.abs(h - 180), s, v)
 	end
 
@@ -779,7 +779,7 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 			if IsValid(submaterialFrame) then
 				local selected, subcount = submaterialFrame:GetSelectedSubMaterials()
 				for _, id in ipairs(selected) do
-					colorPicker.Mixer:SetColor(colorable._adv_colours[id])
+					colorPicker.Mixer:SetColor(colorable._adv_colours[id] or color_white)
 				end
 			end
 

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -774,7 +774,9 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 	end)
 
 	local lastThink = CurTime()
-	local lastColorChange = 0
+	-- ENT.LastColorChange is always at least 0. We set it to -1 to ensure that we will always
+	-- refresh the tree at the start
+	local lastColorChange = -1
 	timer.Remove("colortree_think")
 	timer.Create("colortree_think", 0, -1, function()
 		local now = CurTime()

--- a/lua/colortree/server/net.lua
+++ b/lua/colortree/server/net.lua
@@ -1,4 +1,5 @@
 util.AddNetworkString("colortree_sync")
+util.AddNetworkString("colortree_update")
 util.AddNetworkString("modeltree_sync")
 util.AddNetworkString("modeltree_modelrequest")
 util.AddNetworkString("modeltree_modelresponse")

--- a/lua/colortree/shared/helpers.lua
+++ b/lua/colortree/shared/helpers.lua
@@ -41,4 +41,10 @@ function helpers.decodeData(data)
 	return util.JSONToTable(util.Decompress(data))
 end
 
+---@param ent Colorable|Entity
+---@return boolean
+function helpers.isAdvancedColorsInstalled(ent)
+	return isfunction(ent.SetSubColor)
+end
+
 return helpers

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -35,11 +35,13 @@
 
 ---An entity that has a color method and fields from other addons
 ---@class Colorable: Entity
+---@field LastColorChange number
+---@field GetParent fun(self: Colorable): parent: Colorable
 ---@field ProxyentCritGlow Entity -- Glow Tools Entity
 ---@field ProxyentPaintColor Entity -- Hat Painter Entity
 ---@field ProxyentCloakEffect Entity -- Cloak Tool Entity
 ---@field colortree_owner Player
----@field SetSubColor fun(self: Colorable, ind: integer, color: Color)? -- Setter from Advanced Color Tool. We use this to check if it is installed
+---@field SetSubColor fun(self: Colorable, ind: integer, color: Color?)? -- Setter from Advanced Color Tool. We use this to check if it is installed
 ---@field _adv_colours table?
 
 ---Dupe data for color trees

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -35,13 +35,17 @@
 
 ---An entity that has a color method and fields from other addons
 ---@class Colorable: Entity
----@field ProxyentCritGlow Entity
----@field ProxyentPaintColor Entity
+---@field ProxyentCritGlow Entity -- Glow Tools Entity
+---@field ProxyentPaintColor Entity -- Hat Painter Entity
+---@field ProxyentCloakEffect Entity -- Cloak Tool Entity
 ---@field colortree_owner Player
+---@field SetSubColor fun(self: Colorable, ind: integer, color: Color)? -- Setter from Advanced Color Tool. We use this to check if it is installed
+---@field _adv_colours table?
 
 ---Dupe data for color trees
 ---@class ColorTreeData
 ---@field colortree_color Color
+---@field colortree_colors Color[]?
 ---@field colortree_renderMode number
 ---@field colortree_renderFx number
 ---@field colortree_proxyColor ProxyColor
@@ -52,6 +56,7 @@
 ---@field route integer[]?
 ---@field entity integer
 ---@field color Color
+---@field colors Color[]?
 ---@field renderMode number
 ---@field renderFx number
 ---@field proxyColor ProxyColor?

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -138,9 +138,14 @@
 
 ---END TODO
 
+---@class ColorSlider: DPanel
+---@field IsEditing fun(self: ColorSlider): editing: boolean
+
 ---Wrapper for `DColorMixer`
 ---@class ColorTreeMixer: DColorMixer
 ---@field HSV DSlider
+---@field RGB ColorSlider
+---@field Alpha ColorSlider
 
 ---Wrapper for `CtrlColor`
 ---@class ColorTreePicker: Panel

--- a/lua/vgui/colortree_submaterials.lua
+++ b/lua/vgui/colortree_submaterials.lua
@@ -183,8 +183,11 @@ function PANEL:ClearSelection()
 	self.Selection.PreviewIcon:SetTall(self.Selection.PreviewIcon:GetWide())
 	self.Selection.PreviewIcon:SetVisible(false)
 	self.Selection.PreviewIcon:Dock(TOP)
+	self:OnClearSelection()
 	self:RefreshSelection()
 end
+
+function PANEL:OnClearSelection() end
 
 ---Refill the material list with the currently selected submaterials
 function PANEL:RefreshSelection()

--- a/lua/vgui/colortree_submaterials.lua
+++ b/lua/vgui/colortree_submaterials.lua
@@ -229,6 +229,10 @@ end
 ---@param index number submaterial id
 function PANEL:OnSelectedMaterial(index) end
 
+---Event when the user removes the selected subamterial in the material list
+---@param index number submaterial id
+function PANEL:OnRemovedSubMaterial(index) end
+
 ---Clear the gallery for the new selected entity
 function PANEL:RefreshGallery()
 	if not IsValid(self.Entity) then
@@ -252,8 +256,9 @@ function PANEL:RefreshGallery()
 				self.submaterialSet[i - 1] =
 					table.insert(self.submaterials, { i - 1, shortPath(materialPath), material })
 			else
-				table.remove(self.submaterials, self.submaterialSet[i])
+				table.remove(self.submaterials, self.submaterialSet[i - 1])
 				self.submaterialSet[i - 1] = nil
+				self:OnRemovedSubMaterial(i - 1)
 				self:RefreshSubMaterialSet()
 			end
 

--- a/lua/vgui/colortree_submaterials.lua
+++ b/lua/vgui/colortree_submaterials.lua
@@ -1,0 +1,239 @@
+---@class colortree_selection: DPanel
+---@field PreviewIcon DImage
+---@field MaterialList DListView
+---@field ClearButton DButton
+
+---@class colortree_submaterials: DFrame
+---@field Selection colortree_selection
+local PANEL = {}
+
+local WIDTH, HEIGHT = ScrW(), ScrH()
+
+local BACKUP_MATERIAL = Material("null")
+local materialsMap = {}
+local aspectRatios = {}
+
+---@param material IMaterial
+local function getAspectRatio(material)
+	local name = material:GetName()
+	if aspectRatios[name] then
+		return aspectRatios[name]
+	end
+
+	aspectRatios[name] = material:Width() / material:Height()
+	return aspectRatios[name]
+end
+
+---@param materialPath string
+---@return IMaterial
+local function getMaterial(materialPath)
+	if materialsMap[materialPath] then
+		return materialsMap[materialPath]
+	end
+
+	materialsMap[materialPath] = Material(materialPath)
+	return materialsMap[materialPath]
+end
+
+---@param path string
+---@return string
+local function shortPath(path)
+	local split = string.Split(path, "/")
+	return split[#split]
+end
+
+function PANEL:Init()
+	self:SetTitle("Submaterial Gallery")
+
+	self:SetDraggable(false)
+	self:ShowCloseButton(false)
+	self:SetDeleteOnClose(false)
+	self:SetSizable(false)
+
+	self:SetPos(WIDTH * 0.1, HEIGHT * 0.25)
+	self:SetSize(WIDTH * 0.25, HEIGHT * 0.5)
+
+	self.ButtonHeight = 80
+
+	self.Divider = vgui.Create("DHorizontalDivider", self)
+
+	---@type colortree_selection
+	---@diagnostic disable-next-line
+	self.Selection = vgui.Create("DPanel", self)
+	self.Selection.PreviewIcon = vgui.Create("DImage", self.Selection)
+
+	self.Selection.MaterialList = vgui.Create("DListView", self.Selection)
+	self.Selection.MaterialList:AddColumn("Selected")
+	self.Selection.MaterialList:SetMultiSelect(false)
+
+	self.Selection.ClearButton = vgui.Create("DButton", self.Selection)
+	self.Selection.ClearButton:SetText("Clear All")
+	function self.Selection.ClearButton.DoClick()
+		self:ClearSelection()
+	end
+
+	self.Gallery = vgui.Create("DPanel", self)
+	self.Gallery.Scroll = vgui.Create("DScrollPanel", self.Gallery)
+	self.Gallery.Grid = vgui.Create("DIconLayout", self.Gallery.Scroll)
+
+	self.Divider:SetLeft(self.Selection)
+	self.Divider:SetRight(self.Gallery)
+
+	self.Tooltip = vgui.Create("DLabel")
+	self.Tooltip:SetVisible(false)
+	self.Tooltip:SetWrap(true)
+	self.Tooltip:SetDrawOnTop(true)
+	self.Tooltip:SetSize(200, 200)
+	self.Tooltip:SetFont("DefaultFixedDropShadow")
+
+	self.Entity = NULL
+
+	self.submaterials = {}
+	self.submaterialSet = {}
+end
+
+function PANEL:Paint(w, h)
+	local old = DisableClipping(true)
+	DisableClipping(old)
+
+	derma.SkinHook("Paint", "Frame", self, w, h)
+	return true
+end
+
+function PANEL:PerformLayout(width, height)
+	---@diagnostic disable-next-line
+	self.BaseClass.PerformLayout(self, width, height)
+
+	self.Divider:Dock(FILL)
+
+	self.Selection:Dock(LEFT)
+	self.Gallery:Dock(RIGHT)
+	self.Gallery.Scroll:Dock(FILL)
+	self.Gallery.Grid:Dock(FILL)
+
+	self.Selection.PreviewIcon:Dock(TOP)
+	self.Selection.MaterialList:Dock(FILL)
+	self.Selection.ClearButton:Dock(BOTTOM)
+
+	self.Selection.PreviewIcon:SetTall(self.Selection.PreviewIcon:GetWide())
+end
+
+function PANEL:GetSubMaterials()
+	return self.submaterials
+end
+
+function PANEL:TransformSubMaterials(submaterialIds)
+	local transformed = {}
+	local materials = self.Entity:GetMaterials()
+	for _, submaterialId in pairs(submaterialIds) do
+		local submaterial = materials[submaterialId + 1]
+		self.submaterialSet[submaterialId] =
+			table.insert(transformed, { submaterialId, shortPath(submaterial), getMaterial(submaterial) })
+	end
+	return transformed
+end
+
+function PANEL:SetSubMaterials(submaterials)
+	self.submaterials = self:TransformSubMaterials(submaterials)
+	self:RefreshSelection()
+end
+
+function PANEL:RefreshSubMaterialSet()
+	for i, submaterialStruct in ipairs(self.submaterials) do
+		self.submaterialSet[submaterialStruct[1]] = i
+	end
+end
+
+function PANEL:ClearSelection()
+	self.submaterials = {}
+	self.submaterialSet = {}
+	self.Selection.PreviewIcon:SetImage(BACKUP_MATERIAL:GetName())
+	self.Selection.PreviewIcon:SetTall(self.Selection.PreviewIcon:GetWide())
+	self.Selection.PreviewIcon:SetVisible(false)
+	self.Selection.PreviewIcon:Dock(TOP)
+	self:RefreshSelection()
+end
+
+function PANEL:RefreshSelection()
+	local selection = self.Selection
+	local previewIcon = self.Selection.PreviewIcon
+	for i, _ in ipairs(selection.MaterialList:GetLines()) do
+		selection.MaterialList:RemoveLine(i)
+	end
+
+	for _, submaterialStruct in ipairs(self.submaterials) do
+		---@type DListView_Line
+		---@diagnostic disable-next-line
+		local row = selection.MaterialList:AddLine(submaterialStruct[2], submaterialStruct[3])
+
+		function row.OnSelect()
+			---@type IMaterial
+			---@diagnostic disable-next-line
+			local material = row:GetValue(2)
+			local aspectRatio = getAspectRatio(material)
+
+			previewIcon:SetVisible(true)
+			previewIcon:SetImage(material:GetName())
+			previewIcon:SetTall(previewIcon:GetWide() / aspectRatio)
+		end
+	end
+	selection.MaterialList:SetDirty(true)
+end
+
+function PANEL:RefreshGallery()
+	if not IsValid(self.Entity) then
+		return
+	end
+
+	local materials = self.Entity:GetMaterials()
+
+	for i, materialPath in ipairs(materials) do
+		local materialIcon = vgui.Create("DImageButton", self.Gallery.Grid)
+		materialIcon:SetOnViewMaterial(materialPath, BACKUP_MATERIAL:GetName())
+		materialIcon:SetStretchToFit(true)
+
+		local material = getMaterial(materialPath)
+		local aspectRatio = getAspectRatio(material)
+
+		materialIcon:SetSize(aspectRatio * self.ButtonHeight, self.ButtonHeight)
+
+		materialIcon.DoClick = function()
+			if not self.submaterialSet[i - 1] then
+				self.submaterialSet[i - 1] =
+					table.insert(self.submaterials, { i - 1, shortPath(materialPath), material })
+			else
+				table.remove(self.submaterials, self.submaterialSet[i])
+				self.submaterialSet[i - 1] = nil
+				self:RefreshSubMaterialSet()
+			end
+
+			self:RefreshSelection()
+		end
+
+		materialIcon.TestHover = function(_, x, y)
+			self.Tooltip:SetVisible(true)
+			self.Tooltip:SetPos(x + 10, y - 0.55 * self.Tooltip:GetTall())
+			self.Tooltip:SetText(shortPath(materialPath))
+		end
+
+		self.Gallery.Grid:Add(materialIcon)
+	end
+end
+
+---@param entity Entity
+function PANEL:SetEntity(entity)
+	self.Entity = entity
+	self:RefreshGallery()
+end
+
+function PANEL:OnRemove()
+	self.Tooltip:Remove()
+end
+
+function PANEL:SetVisible(visible)
+	---@diagnostic disable-next-line
+	self.BaseClass.SetVisible(self, visible)
+	self.Tooltip:SetVisible(visible)
+end
+
+vgui.Register("colortree_submaterials", PANEL, "DFrame")

--- a/lua/weapons/gmod_tool/stools/colortree.lua
+++ b/lua/weapons/gmod_tool/stools/colortree.lua
@@ -116,7 +116,9 @@ function TOOL:RightClick(tr)
 	self:SetColorable(IsValid(tr.Entity) and tr.Entity or NULL)
 	if IsValid(tr.Entity) then
 		tr.Entity:CallOnRemove("colortree_removeentity", function()
-			self:SetColorable(NULL)
+			if IsValid(self:GetWeapon()) then
+				self:SetColorable(NULL)
+			end
 		end)
 	end
 	return true

--- a/lua/weapons/gmod_tool/stools/colortree.lua
+++ b/lua/weapons/gmod_tool/stools/colortree.lua
@@ -112,7 +112,7 @@ function TOOL:RightClick(tr)
 end
 
 if SERVER then
-	---Set the colors of the entity by default or throuregh material proxy
+	---Set the colors of the entity by default or through material proxy
 	---@param ply Player
 	---@param ent Colorable|Entity
 	---@param data ColorTreeData
@@ -123,6 +123,11 @@ if SERVER then
 
 		-- Advanced Colour Tool Condition
 		if isAdvancedColorsInstalled(ent) then
+			if not ent._adv_colours then
+				---@diagnostic disable-next-line
+				ent:SetSubColor(0, nil)
+			end
+
 			for id, color in pairs(data.colortree_colors) do
 				-- Only update the color when its different
 				if ent._adv_colours[id] ~= Color(color.r, color.g, color.b, color.a) then

--- a/lua/weapons/gmod_tool/stools/colortree.lua
+++ b/lua/weapons/gmod_tool/stools/colortree.lua
@@ -62,7 +62,7 @@ if SERVER then
 		if IsValid(ply) then
 			ent.colortree_owner = ply
 		end
-		-- FIXME: Advanced Colors seem to not save correctly
+
 		if data.colortree_colors and next(data.colortree_colors) then
 			for id, color in pairs(data.colortree_colors) do
 				---@diagnostic disable-next-line
@@ -75,6 +75,7 @@ if SERVER then
 		if data.colortree_color.a < 255 then
 			ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
 		end
+
 		if data.colortree_proxyColor then
 			local hasCloak = false
 			local hasGlow = false
@@ -116,6 +117,7 @@ if SERVER then
 			end
 		end
 
+		duplicator.ClearEntityModifier(ent, "colortree")
 		duplicator.StoreEntityModifier(ent, "colortree", data)
 	end
 

--- a/lua/weapons/gmod_tool/stools/colortree.lua
+++ b/lua/weapons/gmod_tool/stools/colortree.lua
@@ -62,6 +62,13 @@ if SERVER then
 		if IsValid(ply) then
 			ent.colortree_owner = ply
 		end
+		-- FIXME: Advanced Colors seem to not save correctly
+		if data.colortree_colors and next(data.colortree_colors) then
+			for id, color in pairs(data.colortree_colors) do
+				---@diagnostic disable-next-line
+				ent:SetSubColor(id, Color(color.r, color.g, color.b, color.a))
+			end
+		end
 		ent:SetColor(data.colortree_color)
 		ent:SetRenderMode(data.colortree_renderMode)
 		ent:SetRenderFX(data.colortree_renderFx)
@@ -118,6 +125,7 @@ if SERVER then
 	local function getColorTreeData(node)
 		return {
 			colortree_color = node.color,
+			colortree_colors = node.colors,
 			colortree_renderMode = node.renderMode,
 			colortree_renderFx = node.renderFx,
 			colortree_proxyColor = node.proxyColor,

--- a/lua/weapons/gmod_tool/stools/colortree.lua
+++ b/lua/weapons/gmod_tool/stools/colortree.lua
@@ -75,22 +75,26 @@ do -- Keep track of the last time the (sub)colors of an entity or its children h
 end
 
 local lastColorable = NULL
+local lastValidColorable = false
 function TOOL:Think()
 	local currentColorable = self:GetColorable()
-	if currentColorable == NULL then
+	local validColorable = IsValid(currentColorable)
+
+	if currentColorable == lastColorable and validColorable == lastValidColorable then
+		return
+	end
+
+	if not validColorable then
 		self:SetOperation(0)
 	else
 		self:SetOperation(1)
-	end
-
-	if currentColorable == lastColorable then
-		return
 	end
 
 	if CLIENT then
 		self:RebuildControlPanel(currentColorable)
 	end
 	lastColorable = currentColorable
+	lastValidColorable = validColorable
 end
 
 ---@param newColorable Colorable|Entity
@@ -108,6 +112,11 @@ end
 ---@return boolean
 function TOOL:RightClick(tr)
 	self:SetColorable(IsValid(tr.Entity) and tr.Entity or NULL)
+	if IsValid(tr.Entity) then
+		tr.Entity:CallOnRemove("colortree_removeentity", function()
+			self:SetColorable(NULL)
+		end)
+	end
 	return true
 end
 
@@ -273,6 +282,8 @@ hook.Add("PreDrawHalos", "colortree_halos", function()
 end)
 
 TOOL.Information = {
-	{ name = "info", operation = 0 },
-	{ name = "right", operation = 0 },
+	{ name = "info.0", op = 0 },
+	{ name = "info.1", op = 1 },
+	{ name = "right.0", op = 0 },
+	{ name = "right.1", op = 1 },
 }

--- a/resource/localization/en/colortree_tools.properties
+++ b/resource/localization/en/colortree_tools.properties
@@ -1,8 +1,9 @@
 tool.colortree.name=Color Tree
 tool.colortree.desc=Color an entity's children and its descendants
-tool.colortree.0=Right-click on an entity to view its descendants' color
-tool.colortree.1=Change the color in the control panel to set the entity's color
-tool.colortree.right=Select an entity
+tool.colortree.info.0=Right-click on an entity to view its descendants' color
+tool.colortree.info.1=Change the color in the control panel to set the entity's color
+tool.colortree.right.0=Select an entity
+tool.colortree.right.1=Select the world to stop editing
 tool.colortree.reload=Reset the colors in the entity and its descendants
 tool.colortree.color=Set the color for the selected entity in the entity's hierarchy
 tool.colortree.lock=Lock color tree


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8ccfdfb7-2ec2-4d2d-a85a-f6b01f6989bc)

- If Advanced Colour Tool is installed, this adds a submaterial explorer GUI to the left of the control panel, for the selected node. Selecting the submaterial from the selected list and using the color mixer with no proxies selected will allow the submaterial to be colored individually, with natural support for bonemerged entities.
- Advanced Colours now save between dupes. This behavior is only seen with the Color Tree tool (it is yet to be seen if Advanced Colour Tool will save dupes properly)