### PR TITLE
Material Tree Implementation

### DIFF
--- a/lua/autorun/colortree.lua
+++ b/lua/autorun/colortree.lua
@@ -4,6 +4,7 @@ if SERVER then
 	AddCSLuaFile("colortree/client/proxyConVars.lua")
 	AddCSLuaFile("colortree/client/colorui.lua")
 	AddCSLuaFile("colortree/client/modelui.lua")
+	AddCSLuaFile("colortree/client/materialui.lua")
 
 	include("colortree/server/net.lua")
 end

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -8,6 +8,8 @@ local proxyTransformers = pt.proxyTransformers
 
 local getValidModelChildren, encodeData, isAdvancedColorsInstalled =
 	helpers.getValidModelChildren, helpers.encodeData, helpers.isAdvancedColorsInstalled
+local getModelName, getModelNameNice, getModelNodeIconPath =
+	helpers.getModelName, helpers.getModelNameNice, helpers.getModelNodeIconPath
 
 local ui = {}
 
@@ -107,41 +109,6 @@ local function makeCategory(cPanel, name, type)
 	category:SetLabel(name)
 	cPanel:AddItem(category)
 	return category
-end
-
----Get a nicely formatted model name
----@param entity Entity
----@return string
-local function getModelNameNice(entity)
-	local mdl = string.Split(entity:GetModel() or "", "/")
-	mdl = mdl[#mdl]
-	return string.NiceName(string.sub(mdl, 1, #mdl - 4))
-end
-
----Get the model name without the path
----@param entity Entity
----@return string
-local function getModelName(entity)
-	local mdl = string.Split(entity:GetModel(), "/")
-	mdl = mdl[#mdl]
-	return mdl
-end
-
----Grab the entity's model icon
----@source https://github.com/NO-LOAFING/AdvBonemerge/blob/371b790d00d9bcbb62845ce8785fc6b98fbe8ef4/lua/weapons/gmod_tool/stools/advbonemerge.lua#L1079
----@param ent Entity
----@return string iconPath
-local function getModelNodeIconPath(ent)
-	local skinid = ent:GetSkin() or 0
-	local modelicon = "spawnicons/" .. string.StripExtension(ent:GetModel()) .. ".png"
-	if skinid > 0 then
-		modelicon = "spawnicons/" .. string.StripExtension(ent:GetModel()) .. "_skin" .. skinid .. ".png"
-	end
-
-	if not file.Exists("materials/" .. modelicon, "GAME") then
-		modelicon = "icon16/bricks.png"
-	end
-	return modelicon
 end
 
 ---Reset the colors of a (sub)tree
@@ -757,24 +724,26 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 	end
 
 	hook.Remove("OnContextMenuOpen", "colortree_hookcontext")
-	hook.Add("OnContextMenuOpen", "colortree_hookcontext", function()
-		local tool = LocalPlayer():GetTool()
-		-- Advanced Colors
-		if IsValid(submaterialFrame) and tool and tool.Mode == "colortree" then
-			submaterialFrame:SetVisible(true)
-			submaterialFrame:MakePopup()
-		end
-	end)
+	-- Advanced Colors
+	if IsValid(submaterialFrame) then
+		hook.Add("OnContextMenuOpen", "colortree_hookcontext", function()
+			local tool = LocalPlayer():GetTool()
+			if tool and tool.Mode == "colortree" then
+				submaterialFrame:SetVisible(true)
+				submaterialFrame:MakePopup()
+			end
+		end)
+	end
 
 	hook.Remove("OnContextMenuClose", "colortree_hookcontext")
-	hook.Add("OnContextMenuClose", "colortree_hookcontext", function()
-		-- Advanced Colors
-		if IsValid(submaterialFrame) then
+	-- Advanced Colors
+	if IsValid(submaterialFrame) then
+		hook.Add("OnContextMenuClose", "colortree_hookcontext", function()
 			submaterialFrame:SetVisible(false)
 			submaterialFrame:SetMouseInputEnabled(false)
 			submaterialFrame:SetKeyboardInputEnabled(false)
-		end
-	end)
+		end)
+	end
 
 	local lastThink = CurTime()
 	-- ENT.LastColorChange is always at least 0. We set it to -1 to ensure that we will always

--- a/lua/colortree/client/colorui.lua
+++ b/lua/colortree/client/colorui.lua
@@ -369,6 +369,7 @@ local function setSubMaterialEntity(entity, submaterials, panelChildren, panelSt
 	end
 
 	submaterialFrame = vgui.Create("colortree_submaterials")
+	submaterialFrame:SetHelp("#tool.colortree.submaterial.help")
 	submaterialFrame:SetVisible(lastVisible)
 	submaterialFrame:SetEntity(entity)
 	if submaterials then

--- a/lua/colortree/client/materialui.lua
+++ b/lua/colortree/client/materialui.lua
@@ -1,0 +1,451 @@
+---@module "colortree.shared.helpers"
+local helpers = include("colortree/shared/helpers.lua")
+
+local getValidModelChildren, encodeData = helpers.getValidModelChildren, helpers.encodeData
+local getModelName, getModelNameNice, getModelNodeIconPath =
+	helpers.getModelName, helpers.getModelNameNice, helpers.getModelNodeIconPath
+
+local ui = {}
+
+---Update the entity's appearance in the client.
+---This happens every tick on the client as opposed to the server, to optimize on the outgoing net rate.
+---@param tree MaterialTree
+local function setMaterialClient(tree)
+	local entity = Entity(tree.entity)
+	if not IsValid(entity) then
+		return
+	end
+
+	entity:SetMaterial(tree.material)
+	for ind, submaterial in pairs(tree.submaterials) do
+		entity:SetSubMaterial(ind, submaterial)
+	end
+
+	if not tree.children and #tree.children == 0 then
+		return
+	end
+	for _, child in ipairs(tree.children) do
+		setMaterialClient(child)
+	end
+end
+
+---Helper for DForm
+---@param cPanel ControlPanel|DForm
+---@param name string
+---@param type "ControlPanel"|"DForm"
+---@return ControlPanel|DForm
+local function makeCategory(cPanel, name, type)
+	---@type DForm|ControlPanel
+	local category = vgui.Create(type, cPanel)
+
+	category:SetLabel(name)
+	cPanel:AddItem(category)
+	return category
+end
+
+---@param entity Entity
+---@return string[]
+local function getSubMaterials(entity)
+	local submaterials = {}
+	for ind, _ in ipairs(entity:GetMaterials()) do
+		local submaterial = entity:GetSubMaterial(ind - 1)
+		if submaterial and #submaterial ~= 0 and submaterial ~= "nil" then
+			submaterials[ind - 1] = submaterial
+		end
+	end
+
+	return submaterials
+end
+
+---Reset the materials of a (sub)tree
+---@param tree MaterialTree
+local function resetTree(tree)
+	tree.material = ""
+	tree.submaterials = {}
+	if not tree.children or #tree.children == 0 then
+		return
+	end
+
+	for _, child in ipairs(tree.children) do
+		resetTree(child)
+	end
+end
+
+---Send the entity material tree to the server
+---@param tree MaterialTree
+local function syncTree(tree)
+	local data = encodeData(tree)
+	net.Start("materialtree_sync", true)
+	net.WriteUInt(#data, 17)
+	net.WriteData(data)
+	net.SendToServer()
+end
+
+---Get changes to the entity's material tree from an external source
+---@param tree MaterialTree
+local function refreshTree(tree)
+	local entity = tree.entity and Entity(tree.entity) or NULL
+	tree.material = IsValid(entity) and entity:GetMaterial() or ""
+	for ind, _ in ipairs(entity:GetMaterials()) do
+		local submaterial = entity:GetSubMaterial(ind)
+		if submaterial and #submaterial ~= 0 and submaterial ~= "nil" then
+			tree.submaterials[ind - 1] = submaterial
+		else
+			tree.submaterials[ind - 1] = nil
+		end
+	end
+	if not tree.children or #tree.children == 0 then
+		return
+	end
+
+	for _, child in ipairs(tree.children) do
+		refreshTree(child)
+	end
+end
+
+---Add hooks and material tree pointers
+---@param parent MaterialTreePanel_Node
+---@param entity Entity
+---@param info MaterialTree
+---@param rootInfo MaterialTree
+---@return MaterialTreePanel_Node
+local function addNode(parent, entity, info, rootInfo)
+	local node = parent:AddNode(getModelNameNice(entity))
+	---@cast node MaterialTreePanel_Node
+
+	function node:DoRightClick()
+		if not IsValid(entity) then
+			return
+		end
+
+		local menu = DermaMenu()
+		menu:AddOption("Reset Model", function()
+			resetTree(info)
+			syncTree(rootInfo)
+		end)
+
+		menu:Open()
+	end
+
+	node.Icon:SetImage(getModelNodeIconPath(entity))
+	node.info = info
+
+	return node
+end
+
+---Construct the material tree
+---@param parent Entity
+---@return MaterialTree
+local function entityHierarchy(parent, route)
+	local tree = {}
+	if not IsValid(parent) then
+		return tree
+	end
+
+	---@type Entity[]
+	local children = getValidModelChildren(parent)
+
+	for i, child in ipairs(children) do
+		if child.GetModel and child:GetModel() ~= "models/error.mdl" then
+			table.insert(route, 1, i)
+
+			---@type MaterialTree
+			local node = {
+				parent = parent:EntIndex(),
+				route = route,
+				entity = child:EntIndex(),
+				material = child:GetMaterial(),
+				submaterials = getSubMaterials(child),
+				children = entityHierarchy(child, route),
+			}
+			table.insert(tree, node)
+			route = {}
+		end
+	end
+
+	return tree
+end
+
+---Construct the DTree from the entity material tree
+---@param tree MaterialTree
+---@param nodeParent MaterialTreePanel_Node
+---@param root MaterialTree
+local function hierarchyPanel(tree, nodeParent, root)
+	for _, child in ipairs(tree) do
+		local childEntity = Entity(child.entity)
+		if not IsValid(childEntity) or not childEntity.GetModel or not childEntity:GetModel() then
+			continue
+		end
+
+		local node = addNode(nodeParent, childEntity, child, root)
+
+		if #child.children > 0 then
+			hierarchyPanel(child.children, node, root)
+		end
+	end
+end
+
+---Construct the `entity`'s material tree
+---@param treePanel MaterialTreePanel
+---@param entity Entity
+---@returns MaterialTree
+local function buildTree(treePanel, entity)
+	if IsValid(treePanel.ancestor) then
+		treePanel.ancestor:Remove()
+	end
+
+	---@type MaterialTree
+	local hierarchy = {
+		entity = entity:EntIndex(),
+		material = entity:GetMaterial(),
+		submaterials = getSubMaterials(entity),
+		children = entityHierarchy(entity, {}),
+	}
+
+	---@type MaterialTreePanel_Node
+	---@diagnostic disable-next-line
+	treePanel.ancestor = addNode(treePanel, entity, hierarchy, hierarchy)
+	treePanel.ancestor.Icon:SetImage(getModelNodeIconPath(entity))
+	treePanel.ancestor.info = hierarchy
+	hierarchyPanel(hierarchy.children, treePanel.ancestor, hierarchy)
+
+	return hierarchy
+end
+
+---@type colortree_submaterials
+local submaterialFrame = nil
+local settingMaterialEntry = false
+
+---Set the entity for the submaterial frame.
+---
+---~~VENT:~~
+---
+---~~the cringiest thing to exist 🤮🤮🤮, because panels don't update immediately for some reason (need to move the divider to see it happen)
+---so we force it with the worst thing possible: recreating the vgui 🤢~~
+---@param entity Entity
+---@param submaterials table?
+---@param panelChildren MaterialPanelChildren
+---@param panelState MaterialPanelState
+local function setSubMaterialEntity(entity, submaterials, panelChildren, panelState)
+	local lastVisible = false
+	if IsValid(submaterialFrame) then
+		lastVisible = submaterialFrame:IsVisible()
+		submaterialFrame:Remove()
+	end
+
+	submaterialFrame = vgui.Create("colortree_submaterials")
+	submaterialFrame:SetVisible(lastVisible)
+	submaterialFrame:SetEntity(entity)
+	if submaterials then
+		submaterialFrame:SetSubMaterials(submaterials)
+	end
+
+	-- We'll hook the submaterial frame here for the time being
+	if submaterialFrame and IsValid(submaterialFrame) then
+		function submaterialFrame:OnSelectedMaterial(id)
+			local node = panelChildren.treePanel:GetSelectedItem()
+
+			settingMaterialEntry = true
+			panelChildren.materialEntry:SetValue(node.info.submaterials[id] or "")
+			settingMaterialEntry = false
+		end
+
+		function submaterialFrame:OnRemovedSubMaterial(id)
+			local node = panelChildren.treePanel:GetSelectedItem()
+			node.info.submaterials[id] = nil
+			syncTree(panelState.materialTree)
+		end
+
+		function submaterialFrame:OnClearSelection()
+			local node = panelChildren.treePanel:GetSelectedItem()
+			node.info.submaterials = {}
+			syncTree(panelState.materialTree)
+		end
+	end
+end
+
+---@param cPanel DForm|ControlPanel
+---@param panelProps MaterialPanelProps
+---@param panelState MaterialPanelState
+---@return MaterialPanelChildren
+function ui.ConstructPanel(cPanel, panelProps, panelState)
+	local materialEntity = panelProps.materialEntity
+
+	local treeForm = makeCategory(cPanel, "Entity Hierarchy", "DForm")
+	treeForm:Help(
+		IsValid(materialEntity) and "Entity hierarchy for " .. getModelName(materialEntity) or "No entity selected"
+	)
+	local treePanel = vgui.Create("DTree", treeForm)
+	---@cast treePanel MaterialTreePanel
+	if IsValid(materialEntity) then
+		panelState.materialTree = buildTree(treePanel, materialEntity)
+	else
+		panelState.haloedEntity = NULL
+		panelState.materialTree = {} ---@diagnostic disable-line
+	end
+	treeForm:AddItem(treePanel)
+	treePanel:Dock(TOP)
+	treePanel:SetSize(treeForm:GetWide(), 250)
+
+	local materialForm = makeCategory(cPanel, "Material", "ControlPanel")
+	materialForm:Help("#tool.materialtree.material")
+	local materialEntry = vgui.Create("DTextEntry", cPanel)
+	---@cast materialEntry DTextEntry
+	materialForm:AddItem(materialEntry)
+	materialEntry:Dock(TOP)
+
+	if IsValid(materialEntity) then
+		materialEntry:SetText(materialEntity:GetMaterial())
+	end
+
+	---@source https://github.com/Facepunch/garrysmod/blob/e47ac049d026f922867ee3adb2c4746fb1244300/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/material.lua#L136
+	---START SOURCE
+	-- Remove duplicate materials. table.HasValue is used to preserve material order
+	local materials = {}
+	for id, str in ipairs( list.Get( "OverrideMaterials" ) ) do
+		if ( !table.HasValue( materials, str ) ) then
+			table.insert( materials, str )
+		end
+	end
+
+	local materialGallery = materialForm:MatSelect( "material_override", materials, true, 0.25, 0.25 )
+	---END SOURCE
+
+	local settings = makeCategory(cPanel, "Settings", "DForm")
+
+	---@type DCheckBoxLabel
+	---@diagnostic disable-next-line
+	local lock = settings:CheckBox("#tool.materialtree.lock", "materialtree_lock")
+	lock:SetTooltip("#tool.materialtree.lock.tooltip")
+
+	if IsValid(submaterialFrame) then
+		submaterialFrame:Remove()
+	end
+
+	return {
+		treePanel = treePanel,
+		materialForm = materialForm,
+		materialEntry = materialEntry,
+		materialGallery = materialGallery,
+		lock = lock,
+	}
+end
+
+---@param panelChildren MaterialPanelChildren
+---@param panelProps MaterialPanelProps
+---@param panelState MaterialPanelState
+function ui.HookPanel(panelChildren, panelProps, panelState)
+	local materialEntity = panelProps.materialEntity
+
+	local treePanel = panelChildren.treePanel
+	local materialForm = panelChildren.materialForm
+	local materialEntry = panelChildren.materialEntry
+	local materialGallery = panelChildren.materialGallery
+	local lock = panelChildren.lock
+
+	local shouldSet = false
+
+	function materialGallery:OnSelect(material)
+		materialEntry:SetValue(material)
+	end
+
+	function materialEntry:OnValueChange(newVal)
+		-- In case we are requesting a material change
+		if settingMaterialEntry then
+			return
+		end
+		local node = treePanel:GetSelectedItem()
+		local submaterials = submaterialFrame:GetSelectedSubMaterials()
+		if #submaterials > 0 then
+			for _, id in ipairs(submaterials) do
+				node.info.submaterials[id] = newVal
+			end
+		else
+			node.info.material = newVal
+		end
+
+		-- setMaterialClient(node.info)
+		shouldSet = true
+	end
+
+	---@param node MaterialTreePanel_Node
+	function treePanel:OnNodeSelected(node)
+		local entity = Entity(node.info.entity)
+		settingMaterialEntry = true
+
+		setSubMaterialEntity(entity, table.GetKeys(node.info.submaterials), panelChildren, panelState)
+		materialEntry:SetValue(node.info.material)
+		panelState.haloedEntity = Entity(node.info.entity)
+
+		refreshTree(node.info)
+
+		settingMaterialEntry = false
+	end
+
+	-- Initialize with our selection
+	if IsValid(treePanel) and IsValid(treePanel.ancestor) then
+		treePanel:SetSelectedItem(treePanel.ancestor)
+		setSubMaterialEntity(materialEntity, table.GetKeys(getSubMaterials(materialEntity)), panelChildren, panelState)
+		refreshTree(panelState.materialTree)
+	end
+
+	hook.Remove("OnContextMenuOpen", "materialtree_hookcontext")
+	if IsValid(submaterialFrame) then
+		hook.Add("OnContextMenuOpen", "materialtree_hookcontext", function()
+			local tool = LocalPlayer():GetTool()
+			if tool and tool.Mode == "materialtree" then
+				submaterialFrame:SetVisible(true)
+				submaterialFrame:MakePopup()
+			end
+		end)
+	end
+
+	hook.Remove("OnContextMenuClose", "materialtree_hookcontext")
+	if IsValid(submaterialFrame) then
+		hook.Add("OnContextMenuClose", "materialtree_hookcontext", function()
+			submaterialFrame:SetVisible(false)
+			submaterialFrame:SetMouseInputEnabled(false)
+			submaterialFrame:SetKeyboardInputEnabled(false)
+		end)
+	end
+
+	---@return boolean
+	local function checkEditing()
+		return materialEntry:HasFocus()
+	end
+
+	local lastThink = CurTime()
+	local lastMaterialChange = -1
+	timer.Remove("materialtree_think")
+	timer.Create("materialtree_think", 0, -1, function()
+		local now = CurTime()
+		local editing = checkEditing()
+		if now - lastThink > 0.1 and shouldSet and not editing then
+			syncTree(panelState.materialTree)
+			lastThink = now
+			shouldSet = false
+		end
+
+		-- Whether we should receive updates from the server or not.
+		-- Useful if we want an external source to modify the material tree of the entity
+		if lock:GetChecked() then
+			return
+		end
+
+		if editing then
+			return
+		end
+
+		if not IsValid(materialEntity) then
+			return
+		end
+
+		if materialEntity.LastMaterialChange and materialEntity.LastMaterialChange ~= lastMaterialChange then
+			refreshTree(panelState.materialTree)
+			lastMaterialChange = materialEntity.LastMaterialChange
+		end
+	end)
+	timer.Start("materialtree_think")
+end
+
+return ui

--- a/lua/colortree/client/materialui.lua
+++ b/lua/colortree/client/materialui.lua
@@ -87,7 +87,7 @@ local function refreshTree(tree)
 	local entity = tree.entity and Entity(tree.entity) or NULL
 	tree.material = IsValid(entity) and entity:GetMaterial() or ""
 	for ind, _ in ipairs(entity:GetMaterials()) do
-		local submaterial = entity:GetSubMaterial(ind)
+		local submaterial = entity:GetSubMaterial(ind - 1)
 		if submaterial and #submaterial ~= 0 and submaterial ~= "nil" then
 			tree.submaterials[ind - 1] = submaterial
 		else

--- a/lua/colortree/client/materialui.lua
+++ b/lua/colortree/client/materialui.lua
@@ -289,10 +289,15 @@ function ui.ConstructPanel(cPanel, panelProps, panelState)
 
 	local materialForm = makeCategory(cPanel, "Material", "ControlPanel")
 	materialForm:Help("#tool.materialtree.material")
-	local materialEntry = vgui.Create("DTextEntry", cPanel)
+	local materialClear = vgui.Create("DButton", materialForm)
+	local materialEntry = vgui.Create("DTextEntry", materialForm)
 	---@cast materialEntry DTextEntry
-	materialForm:AddItem(materialEntry)
-	materialEntry:Dock(TOP)
+	materialForm:AddItem(materialEntry, materialClear)
+	materialEntry:Dock(FILL)
+
+	materialClear:SetText("X")
+	materialClear:SetTooltip("#tool.materialtree.clear.tooltip")
+	materialClear:Dock(RIGHT)
 
 	if IsValid(materialEntity) then
 		materialEntry:SetText(materialEntity:GetMaterial())
@@ -326,6 +331,7 @@ function ui.ConstructPanel(cPanel, panelProps, panelState)
 		treePanel = treePanel,
 		materialForm = materialForm,
 		materialEntry = materialEntry,
+		materialClear = materialClear,
 		materialGallery = materialGallery,
 		lock = lock,
 	}
@@ -340,6 +346,7 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 	local treePanel = panelChildren.treePanel
 	local materialForm = panelChildren.materialForm
 	local materialEntry = panelChildren.materialEntry
+	local materialClear = panelChildren.materialClear
 	local materialGallery = panelChildren.materialGallery
 	local lock = panelChildren.lock
 
@@ -347,6 +354,10 @@ function ui.HookPanel(panelChildren, panelProps, panelState)
 
 	function materialGallery:OnSelect(material)
 		materialEntry:SetValue(material)
+	end
+
+	function materialClear:DoClick()
+		materialEntry:SetValue("")
 	end
 
 	function materialEntry:OnValueChange(newVal)

--- a/lua/colortree/client/materialui.lua
+++ b/lua/colortree/client/materialui.lua
@@ -234,6 +234,7 @@ local function setSubMaterialEntity(entity, submaterials, panelChildren, panelSt
 	end
 
 	submaterialFrame = vgui.Create("colortree_submaterials")
+	submaterialFrame:SetHelp("#tool.materialtree.submaterial.help")
 	submaterialFrame:SetVisible(lastVisible)
 	submaterialFrame:SetEntity(entity)
 	if submaterials then

--- a/lua/colortree/client/modelui.lua
+++ b/lua/colortree/client/modelui.lua
@@ -2,6 +2,8 @@
 local helpers = include("colortree/shared/helpers.lua")
 
 local getValidModelChildren, encodeData = helpers.getValidModelChildren, helpers.encodeData
+local getModelName, getModelNameNice, getModelNodeIconPath =
+	helpers.getModelName, helpers.getModelNameNice, helpers.getModelNodeIconPath
 
 local ui = {}
 
@@ -68,55 +70,6 @@ local function makeCategory(cPanel, name, type)
 	category:SetLabel(name)
 	cPanel:AddItem(category)
 	return category
-end
-
----Get a nicely formatted model name
----@param entity Entity
----@return string
-local function getModelNameNice(entity)
-	local mdl = string.Split(entity:GetModel() or "", "/")
-	mdl = mdl[#mdl]
-	return string.NiceName(string.sub(mdl, 1, #mdl - 4))
-end
-
----Get the model name without the path
----@param entity Entity
----@return string
-local function getModelName(entity)
-	local mdl = string.Split(entity:GetModel(), "/")
-	mdl = mdl[#mdl]
-	return mdl
-end
-
-local modelSkins = {}
-
----Grab the entity's model icon
----@source https://github.com/NO-LOAFING/AdvBonemerge/blob/371b790d00d9bcbb62845ce8785fc6b98fbe8ef4/lua/weapons/gmod_tool/stools/advbonemerge.lua#L1079
----@param ent Entity
----@param model Model?
----@param skin Skin?
----@return string iconPath
-local function getModelNodeIconPath(ent, model, skin)
-	skin = skin or ent:GetSkin() or 0
-	model = model or ent:GetModel()
-
-	if modelSkins[model .. skin] then
-		return modelSkins[model .. skin]
-	end
-
-	local modelicon = "spawnicons/" .. string.StripExtension(model) .. ".png"
-	local fallback = file.Exists("materials/" .. modelicon, "GAME") and modelicon or "icon16/bricks.png"
-	if skin > 0 then
-		modelicon = "spawnicons/" .. string.StripExtension(model) .. "_skin" .. skin .. ".png"
-	end
-
-	if not file.Exists("materials/" .. modelicon, "GAME") then
-		modelicon = fallback
-	else
-		modelSkins[model .. skin] = modelicon
-	end
-
-	return modelicon
 end
 
 ---Reset the models of a (sub)tree

--- a/lua/colortree/server/net.lua
+++ b/lua/colortree/server/net.lua
@@ -5,3 +5,6 @@ util.AddNetworkString("modeltree_sync")
 util.AddNetworkString("modeltree_update")
 util.AddNetworkString("modeltree_modelrequest")
 util.AddNetworkString("modeltree_modelresponse")
+
+util.AddNetworkString("materialtree_sync")
+util.AddNetworkString("materialtree_update")

--- a/lua/colortree/shared/helpers.lua
+++ b/lua/colortree/shared/helpers.lua
@@ -10,6 +10,55 @@ local MODEL_FILTER = {
 	["models/error.mdl"] = true,
 }
 
+---Get a nicely formatted model name
+---@param entity Entity
+---@return string
+function helpers.getModelNameNice(entity)
+	local mdl = string.Split(entity:GetModel() or "", "/")
+	mdl = mdl[#mdl]
+	return string.NiceName(string.sub(mdl, 1, #mdl - 4))
+end
+
+---Get the model name without the path
+---@param entity Entity
+---@return string
+function helpers.getModelName(entity)
+	local mdl = string.Split(entity:GetModel(), "/")
+	mdl = mdl[#mdl]
+	return mdl
+end
+
+local modelSkins = {}
+
+---Grab the entity's model icon
+---@source https://github.com/NO-LOAFING/AdvBonemerge/blob/371b790d00d9bcbb62845ce8785fc6b98fbe8ef4/lua/weapons/gmod_tool/stools/advbonemerge.lua#L1079
+---@param ent Entity
+---@param model Model?
+---@param skin Skin?
+---@return string iconPath
+function helpers.getModelNodeIconPath(ent, model, skin)
+	skin = skin or ent:GetSkin() or 0
+	model = model or ent:GetModel()
+
+	if modelSkins[model .. skin] then
+		return modelSkins[model .. skin]
+	end
+
+	local modelicon = "spawnicons/" .. string.StripExtension(model) .. ".png"
+	local fallback = file.Exists("materials/" .. modelicon, "GAME") and modelicon or "icon16/bricks.png"
+	if skin > 0 then
+		modelicon = "spawnicons/" .. string.StripExtension(model) .. "_skin" .. skin .. ".png"
+	end
+
+	if not file.Exists("materials/" .. modelicon, "GAME") then
+		modelicon = fallback
+	else
+		modelSkins[model .. skin] = modelicon
+	end
+
+	return modelicon
+end
+
 ---Get a filtered array of the entity's children
 ---@param entity Entity
 ---@return Entity[]

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -49,6 +49,11 @@
 ---@field LastModelChange number
 ---@field GetParent fun(self: ModelEntity): parent: ModelEntity
 
+---An entity that has a material setter
+---@class MaterialEntity: Entity
+---@field LastMaterialChange number
+---@field GetParent fun(self: MaterialEntity): parent: MaterialEntity
+
 ---Dupe data for color trees
 ---@class ColorTreeData
 ---@field colortree_color Color
@@ -88,6 +93,20 @@
 ---@field bodygroups Bodygroups
 ---@field skin Skin
 ---@field children ModelTree[]
+
+---Dupe data for material trees
+---@class MaterialTreeData
+---@field materialtree_material string
+---@field materialtree_submaterials string[]
+
+---Main structure representing an entity's material tree
+---@class MaterialTree
+---@field parent integer?
+---@field route integer[]?
+---@field entity integer
+---@field material string
+---@field submaterials string[]
+---@field children MaterialTree[]
 
 ---UI
 
@@ -140,6 +159,17 @@
 ---@field ancestor ModelTreePanel_Node
 ---@field GetSelectedItem fun(self: ModelTreePanel): ModelTreePanel_Node
 
+---Wrapper for `DTree_Node`
+---@class MaterialTreePanel_Node: DTree_Node
+---@field info MaterialTree
+---@field Icon DImage
+---@field GetChildNodes fun(self: MaterialTreePanel_Node): MaterialTreePanel_Node[]
+
+---Wrapper for `DTree`
+---@class MaterialTreePanel: DTree
+---@field ancestor MaterialTreePanel_Node
+---@field GetSelectedItem fun(self: MaterialTreePanel): MaterialTreePanel_Node
+
 ---END TODO
 
 ---@class ColorSlider: DPanel
@@ -172,3 +202,21 @@
 ---@field haloedEntity Entity
 ---@field haloColor Color
 ---@field modelTree ModelTree?
+
+---Main material control panel UI
+---@class MaterialPanelChildren
+---@field treePanel MaterialTreePanel
+---@field materialForm DForm
+---@field materialEntry DTextEntry
+---@field materialGallery MatSelect
+---@field lock DCheckBoxLabel
+
+---Immutable properties of the color panel
+---@class MaterialPanelProps
+---@field materialEntity MaterialEntity
+
+---Mutable properties of the color panel
+---@class MaterialPanelState
+---@field haloedEntity Entity
+---@field haloColor Color
+---@field materialTree MaterialTree?

--- a/lua/colortree/types.lua
+++ b/lua/colortree/types.lua
@@ -208,6 +208,7 @@
 ---@field treePanel MaterialTreePanel
 ---@field materialForm DForm
 ---@field materialEntry DTextEntry
+---@field materialClear DButton
 ---@field materialGallery MatSelect
 ---@field lock DCheckBoxLabel
 

--- a/lua/vgui/colortree_submaterials.lua
+++ b/lua/vgui/colortree_submaterials.lua
@@ -51,7 +51,7 @@ function PANEL:Init()
 	self:SetSizable(false)
 
 	self:SetPos(WIDTH * 0.1, HEIGHT * 0.25)
-	self:SetSize(WIDTH * 0.25, HEIGHT * 0.5)
+	self:SetSize(WIDTH * 0.265, HEIGHT * 0.5)
 
 	self.ButtonHeight = 80
 
@@ -59,9 +59,6 @@ function PANEL:Init()
 	self.Help = vgui.Create("DPanel", self)
 	self.Help.Text = vgui.Create("DLabel", self.Help)
 	self.Help.Text:SetDark(true)
-	self.Help.Text:SetText(
-		"Select a material from the gallery, and then click on the lines on the left to edit the color"
-	)
 	self.Help.Text:SetWrap(true)
 
 	---@type colortree_selection
@@ -105,6 +102,10 @@ function PANEL:Init()
 	self.submaterials = {}
 	self.submaterialSet = {}
 	self.hovering = false
+end
+
+function PANEL:SetHelp(text)
+	self.Help.Text:SetText(text)
 end
 
 function PANEL:Paint(w, h)

--- a/lua/weapons/gmod_tool/stools/materialtree.lua
+++ b/lua/weapons/gmod_tool/stools/materialtree.lua
@@ -123,8 +123,9 @@ if SERVER then
 		---Naively, if we don't check if our materials are different, then we would be setting these for
 		---ALL submaterials, which results in unnecessary net calls which lags the client.
 		for ind, _ in ipairs(ent:GetMaterials()) do
-			if ent:GetSubMaterial(ind - 1) ~= tostring(data.materialtree_submaterials[ind - 1]) then
-				ent:SetSubMaterial(ind - 1, data.materialtree_submaterials[ind - 1])
+			local submaterial = data.materialtree_submaterials[ind - 1]
+			if ent:GetSubMaterial(ind - 1) ~= tostring(submaterial) then
+				ent:SetSubMaterial(ind - 1, Either(submaterial and submaterial ~= "nil", submaterial, ""))
 			end
 		end
 

--- a/lua/weapons/gmod_tool/stools/materialtree.lua
+++ b/lua/weapons/gmod_tool/stools/materialtree.lua
@@ -1,0 +1,208 @@
+TOOL.Category = "Render"
+TOOL.Name = "#tool.materialtree.name"
+TOOL.Command = nil
+TOOL.ConfigName = ""
+
+TOOL.ClientConVar["lock"] = 0
+
+local CHANGE_BITS = 7
+local TIME_PRECISION = 10
+
+---@module "colortree.shared.helpers"
+local helpers = include("colortree/shared/helpers.lua")
+
+local decodeData, getAncestor = helpers.decodeData, helpers.getAncestor
+
+do -- Keep track of the last time the materials of an entity or its children has changed
+	---@class MaterialEntity
+	local meta = FindMetaTable("Entity")
+	if meta.materialtree_oldSetMaterial == nil then
+		meta.materialtree_oldSetMaterial = meta.SetMaterial
+	end
+	if meta.materialtree_oldSetSubMaterial == nil then
+		meta.materialtree_oldSetSubMaterial = meta.SetSubMaterial
+	end
+
+	---Propagate the changed material event to the ancestral entity
+	---@param entity Entity
+	local function updateMaterial(entity)
+		net.Start("materialtree_update", true)
+		net.WriteEntity(entity)
+		net.WriteUInt(CurTime() * TIME_PRECISION, CHANGE_BITS)
+		net.Broadcast()
+	end
+
+	function meta:SetMaterial(newMaterial, ...)
+		if not newMaterial then
+			return self:materialtree_oldSetMaterial(newMaterial, ...)
+		end
+
+		local root = getAncestor(self)
+
+		if SERVER then
+			updateMaterial(root)
+		end
+
+		return self:materialtree_oldSetMaterial(newMaterial, ...)
+	end
+
+	function meta:SetSubMaterial(index, newSubMaterial, ...)
+		local now = CurTime()
+		meta.LastMaterialChange = meta.LastMaterialChange or now
+		local root = getAncestor(self)
+
+		if SERVER and meta.LastMaterialChange ~= now then
+			updateMaterial(root)
+		end
+
+		meta.LastMaterialChange = now
+		return self:materialtree_oldSetSubMaterial(index, newSubMaterial, ...)
+	end
+end
+
+local lastMaterialEntity = NULL
+local lastValidMaterial = false
+function TOOL:Think()
+	local currentMaterialEntity = self:GetMaterialEntity()
+	local validMaterial = IsValid(currentMaterialEntity)
+
+	if currentMaterialEntity == lastMaterialEntity and validMaterial == lastValidMaterial then
+		return
+	end
+
+	if not validMaterial then
+		self:SetOperation(0)
+	else
+		self:SetOperation(1)
+	end
+
+	if CLIENT then
+		self:RebuildControlPanel(currentMaterialEntity)
+	end
+	lastMaterialEntity = currentMaterialEntity
+	lastValidMaterial = validMaterial
+end
+
+---@param newMaterialEntity Entity
+function TOOL:SetMaterialEntity(newMaterialEntity)
+	self:GetWeapon():SetNW2Entity("materialtree_entity", newMaterialEntity)
+end
+
+---@return Entity MaterialEntity
+function TOOL:GetMaterialEntity()
+	return self:GetWeapon():GetNW2Entity("materialtree_entity")
+end
+
+---Select the entity to manipulate its entity material tree
+---@param tr table|TraceResult
+---@return boolean
+function TOOL:RightClick(tr)
+	self:SetMaterialEntity(IsValid(tr.Entity) and tr.Entity or NULL)
+	if IsValid(tr.Entity) then
+		tr.Entity:CallOnRemove("materialtree_removeentity", function()
+			if IsValid(self:GetWeapon()) then
+				self:SetMaterialEntity(NULL)
+			end
+		end)
+	end
+	return true
+end
+
+if SERVER then
+	---Set the materials of the entity
+	---@param ply Player
+	---@param ent Entity
+	---@param data MaterialTreeData
+	local function setMaterial(ply, ent, data)
+		if IsValid(ply) then
+			ent.materialtree_owner = ply
+		end
+
+		ent:SetMaterial(data.materialtree_material)
+		---Some tools like Advanced Colour Tool detour the SetSubMaterial function to send some values.
+		---Naively, if we don't check if our materials are different, then we would be setting these for
+		---ALL submaterials, which results in unnecessary net calls which lags the client.
+		for ind, _ in ipairs(ent:GetMaterials()) do
+			if ent:GetSubMaterial(ind - 1) ~= tostring(data.materialtree_submaterials[ind - 1]) then
+				ent:SetSubMaterial(ind - 1, data.materialtree_submaterials[ind - 1])
+			end
+		end
+
+		duplicator.StoreEntityModifier(ent, "materialtree", data)
+	end
+
+	---Transform an entity's material tree into data saved for duping
+	---@param node MaterialTree
+	---@returns MaterialTreeData
+	local function getMaterialTreeData(node)
+		return {
+			materialtree_material = node.material,
+			materialtree_submaterials = node.submaterials,
+		}
+	end
+
+	---Recursively call `setMaterial` on the tree's descendants
+	---@param descendantTree MaterialTree
+	local function setMaterialWithTree(descendantTree, ply)
+		if not descendantTree.children or #descendantTree.children == 0 then
+			return
+		end
+
+		for _, node in ipairs(descendantTree.children) do
+			setMaterial(ply, Entity(node.entity), getMaterialTreeData(node))
+			if node.children and #node.children > 0 then
+				setMaterialWithTree(node.children)
+			end
+		end
+	end
+
+	duplicator.RegisterEntityModifier("materialtree", setMaterial)
+
+	net.Receive("materialtree_sync", function(len, ply)
+		local treeLen = net.ReadUInt(17)
+		local encodedTree = net.ReadData(treeLen)
+		local tree = decodeData(encodedTree)
+
+		setMaterial(ply, Entity(tree.entity), getMaterialTreeData(tree))
+		setMaterialWithTree(tree, ply)
+	end)
+
+	return
+else
+	net.Receive("materialtree_update", function(_, _)
+		local entity = net.ReadEntity()
+		entity.LastMaterialChange = net.ReadUInt(CHANGE_BITS)
+	end)
+end
+
+---@module "colortree.client.materialui"
+local ui = include("colortree/client/materialui.lua")
+
+---@type MaterialPanelState
+local panelState = {
+	haloedEntity = NULL,
+	haloColor = color_white,
+}
+
+---@param cPanel ControlPanel|DForm
+---@param materialEntity MaterialEntity
+function TOOL.BuildCPanel(cPanel, materialEntity)
+	local panelChildren = ui.ConstructPanel(cPanel, { materialEntity = materialEntity }, panelState)
+	ui.HookPanel(panelChildren, { materialEntity = materialEntity }, panelState)
+end
+
+hook.Remove("PreDrawHalos", "materialtree_halos")
+hook.Add("PreDrawHalos", "materialtree_halos", function()
+	local haloedEntity = panelState.haloedEntity
+	local haloColor = panelState.haloColor
+	if IsValid(haloedEntity) then
+		halo.Add({ haloedEntity }, haloColor)
+	end
+end)
+
+TOOL.Information = {
+	{ name = "info.0", op = 0 },
+	{ name = "info.1", op = 1 },
+	{ name = "right.0", op = 0 },
+	{ name = "right.1", op = 1 },
+}

--- a/lua/weapons/gmod_tool/stools/modeltree.lua
+++ b/lua/weapons/gmod_tool/stools/modeltree.lua
@@ -117,7 +117,7 @@ end
 function TOOL:RightClick(tr)
 	self:SetModelEntity(IsValid(tr.Entity) and tr.Entity or NULL)
 	if IsValid(tr.Entity) then
-		tr.Entity:CallOnRemove("colortree_removeentity", function()
+		tr.Entity:CallOnRemove("modeltree_removeentity", function()
 			if IsValid(self:GetWeapon()) then
 				self:SetModelEntity(NULL)
 			end

--- a/resource/localization/en/colortree_tools.properties
+++ b/resource/localization/en/colortree_tools.properties
@@ -21,3 +21,14 @@ tool.modeltree.reload=Reset the models in the entity and its descendants
 tool.modeltree.model=Set the model for the selected entity in the entity's hierarchy
 tool.modeltree.lock=Lock model tree
 tool.modeltree.lock.tooltip=Lock the models of the entity to a certain state. External sources cannot change the model; the models only change when set here.
+
+tool.materialtree.name=Material Tree
+tool.materialtree.desc=Set the material or submaterials of an entity's children and its descendants
+tool.materialtree.info.0=Right-click on an entity to view its descendants' materials or submaterials
+tool.materialtree.info.1=View the control panel to set the entity's materials or submaterials
+tool.materialtree.right.0=Select an entity
+tool.materialtree.right.1=Select the world to stop editing
+tool.materialtree.reload=Reset the materials in the entity and its descendants
+tool.materialtree.material=Set the material for the selected entity in the entity's hierarchy
+tool.materialtree.lock=Lock material tree
+tool.materialtree.lock.tooltip=Lock the materials of the entity to a certain state. External sources cannot change the material; the materials only change when set here.

--- a/resource/localization/en/colortree_tools.properties
+++ b/resource/localization/en/colortree_tools.properties
@@ -10,6 +10,7 @@ tool.colortree.lock=Lock color tree
 tool.colortree.lock.tooltip=Lock the colors of the entity to a certain state. External sources cannot change the color; the colors only change when set here.
 tool.colortree.propagate=Propagate colors
 tool.colortree.propagate.tooltip=Colors set on the parent will be set for its descendants
+tool.colortree.submaterial.help=Select a material from the gallery, and then click on the lines on the left to edit their colors
 
 tool.modeltree.name=Model Tree
 tool.modeltree.desc=Set the model, skin, and bodygroups of an entity's children and its descendants
@@ -33,3 +34,4 @@ tool.materialtree.material=Set the material for the selected entity in the entit
 tool.materialtree.lock=Lock material tree
 tool.materialtree.lock.tooltip=Lock the materials of the entity to a certain state. External sources cannot change the material; the materials only change when set here.
 tool.materialtree.clear.tooltip=Remove the material from the entity
+tool.materialtree.submaterial.help=Select a material from the gallery, and then click on the lines on the left to edit their submaterial

--- a/resource/localization/en/colortree_tools.properties
+++ b/resource/localization/en/colortree_tools.properties
@@ -32,3 +32,4 @@ tool.materialtree.reload=Reset the materials in the entity and its descendants
 tool.materialtree.material=Set the material for the selected entity in the entity's hierarchy
 tool.materialtree.lock=Lock material tree
 tool.materialtree.lock.tooltip=Lock the materials of the entity to a certain state. External sources cannot change the material; the materials only change when set here.
+tool.materialtree.clear.tooltip=Remove the material from the entity


### PR DESCRIPTION
+ Added a Material Tree tool to manipulate the materials of an entity and its hierarchy
+ Added a SubMaterial changer, which uses the same gallery as the color tree, for setting the submaterials
- Moved model name functions to helpers.lua, since its functionality doesn't change between trees
- Moved submaterial gallery checks outside the OnContextMenuClose/Open hook. If we don't have Advanced Colors, or we encounter an issue during debugging, let's not populate the OnContextMenuOpen/Close functions.